### PR TITLE
PR for Planks vice Wood in button creation

### DIFF
--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/acacia_wood_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/acacia_wood_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:acacia_wood"]
+						"items": ["minecraft:acacia_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/birch_wood_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/birch_wood_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:birch_wood"]
+						"items": ["minecraft:birch_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/crimson_hyphae_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/crimson_hyphae_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:crimson_hyphae"]
+						"items": ["minecraft:crimson_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/dark_oak_wood_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/dark_oak_wood_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:dark_oak_wood"]
+						"items": ["minecraft:dark_oak_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/jungle_wood_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/jungle_wood_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:jungle_wood"]
+						"items": ["minecraft:jungle_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/oak_wood_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/oak_wood_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:oak_wood"]
+						"items": ["minecraft:oak_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/spruce_wood_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/spruce_wood_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:spruce_wood"]
+						"items": ["minecraft:spruce_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/warped_hyphae_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/warped_hyphae_button.json
@@ -11,7 +11,7 @@
 			"conditions": {
 				"items": [
 					{
-						"items": ["minecraft:warped_hyphae"]
+						"items": ["minecraft:warped_planks"]
 					}
 				]
 			}

--- a/src/main/resources/data/artisanat/recipes/crafting/acacia_wood_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/acacia_wood_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:acacia_wood"
+			"item": "minecraft:acacia_planks"
 		}
 	},
 	"result": {

--- a/src/main/resources/data/artisanat/recipes/crafting/birch_wood_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/birch_wood_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:birch_wood"
+			"item": "minecraft:birch_planks"
 		}
 	},
 	"result": {

--- a/src/main/resources/data/artisanat/recipes/crafting/crimson_hyphae_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/crimson_hyphae_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:crimson_hyphae"
+			"item": "minecraft:crimson_planks"
 		}
 	},
 	"result": {

--- a/src/main/resources/data/artisanat/recipes/crafting/dark_oak_wood_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/dark_oak_wood_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:dark_oak_wood"
+			"item": "minecraft:dark_oak_planks"
 		}
 	},
 	"result": {

--- a/src/main/resources/data/artisanat/recipes/crafting/jungle_wood_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/jungle_wood_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:jungle_wood"
+			"item": "minecraft:jungle_planks"
 		}
 	},
 	"result": {

--- a/src/main/resources/data/artisanat/recipes/crafting/oak_wood_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/oak_wood_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:oak_wood"
+			"item": "minecraft:oak_planks"
 		}
 	},
 	"result": {

--- a/src/main/resources/data/artisanat/recipes/crafting/spruce_wood_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/spruce_wood_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:spruce_wood"
+			"item": "minecraft:spruce_planks"
 		}
 	},
 	"result": {

--- a/src/main/resources/data/artisanat/recipes/crafting/warped_hyphae_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/warped_hyphae_button.json
@@ -6,7 +6,7 @@
 	],
 	"key": {
 		"#": {
-			"item": "minecraft:warped_hyphae"
+			"item": "minecraft:warped_planks"
 		}
 	},
 	"result": {


### PR DESCRIPTION
PR to address the issue raised in https://github.com/DawnTeamMC/Artisanat/issues/24.

Simple change in appropriate recipe JSON files for wooden button creation for planks vice wood source blocks.  This allows the vanilla MC recipe of wood->planks to be usable again.

**Contributor License Agreement**

By submitting code, assets, or documentation to the repository I am hereby agreeing that:

- I grant Hugman the right to use my contributions under the [LGPL v3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html) license.
- My contributions are of my own work and are free of legal restrictions (such as patents or copyrights).