### PR TITLE
Add missing Mangrove wood items/blocks

### DIFF
--- a/src/main/java/com/hugman/artisanat/init/BlockBundle.java
+++ b/src/main/java/com/hugman/artisanat/init/BlockBundle.java
@@ -19,6 +19,7 @@ public class BlockBundle extends ArtisanatBundle {
 	public static final WoodBlocksBundle JUNGLE_WOOD_BLOCKS = creator(new WoodBlocksBundle(new BlockCreator.Builder().name("jungle_wood").settings(FabricBlockSettings.copyOf(Blocks.JUNGLE_WOOD))));
 	public static final WoodBlocksBundle ACACIA_WOOD_BLOCKS = creator(new WoodBlocksBundle(new BlockCreator.Builder().name("acacia_wood").settings(FabricBlockSettings.copyOf(Blocks.ACACIA_WOOD))));
 	public static final WoodBlocksBundle DARK_OAK_WOOD_BLOCKS = creator(new WoodBlocksBundle(new BlockCreator.Builder().name("dark_oak_wood").settings(FabricBlockSettings.copyOf(Blocks.DARK_OAK_WOOD))));
+	public static final WoodBlocksBundle MANGROVE_WOOD_BLOCKS = creator(new WoodBlocksBundle(new BlockCreator.Builder().name("mangrove_wood").settings(FabricBlockSettings.copyOf(Blocks.MANGROVE_WOOD))));
 	public static final WoodBlocksBundle CRIMSON_HYPHAE_BLOCKS = creator(new WoodBlocksBundle(new BlockCreator.Builder().name("crimson_hyphae").settings(FabricBlockSettings.copyOf(Blocks.CRIMSON_HYPHAE))));
 	public static final WoodBlocksBundle WARPED_HYPHAE_BLOCKS = creator(new WoodBlocksBundle(new BlockCreator.Builder().name("warped_hyphae").settings(FabricBlockSettings.copyOf(Blocks.WARPED_HYPHAE))));
 

--- a/src/main/resources/assets/artisanat/blockstates/mangrove_wood_button.json
+++ b/src/main/resources/assets/artisanat/blockstates/mangrove_wood_button.json
@@ -1,0 +1,118 @@
+{
+	"variants": {
+		"face=floor,facing=east,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"y": 90
+		},
+		"face=floor,facing=west,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"y": 270
+		},
+		"face=floor,facing=south,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"y": 180
+		},
+		"face=floor,facing=north,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed"
+		},
+		"face=wall,facing=east,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"uvlock": true,
+			"x": 90,
+			"y": 90
+		},
+		"face=wall,facing=west,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"uvlock": true,
+			"x": 90,
+			"y": 270
+		},
+		"face=wall,facing=south,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"uvlock": true,
+			"x": 90,
+			"y": 180
+		},
+		"face=wall,facing=north,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"uvlock": true,
+			"x": 90
+		},
+		"face=ceiling,facing=east,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"x": 180,
+			"y": 270
+		},
+		"face=ceiling,facing=west,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"x": 180,
+			"y": 90
+		},
+		"face=ceiling,facing=south,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"x": 180
+		},
+		"face=ceiling,facing=north,powered=false": {
+			"model": "artisanat:block/mangrove_wood_button/unpressed",
+			"x": 180,
+			"y": 180
+		},
+		"face=floor,facing=east,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"y": 90
+		},
+		"face=floor,facing=west,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"y": 270
+		},
+		"face=floor,facing=south,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"y": 180
+		},
+		"face=floor,facing=north,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed"
+		},
+		"face=wall,facing=east,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"uvlock": true,
+			"x": 90,
+			"y": 90
+		},
+		"face=wall,facing=west,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"uvlock": true,
+			"x": 90,
+			"y": 270
+		},
+		"face=wall,facing=south,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"uvlock": true,
+			"x": 90,
+			"y": 180
+		},
+		"face=wall,facing=north,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"uvlock": true,
+			"x": 90
+		},
+		"face=ceiling,facing=east,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"x": 180,
+			"y": 270
+		},
+		"face=ceiling,facing=west,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"x": 180,
+			"y": 90
+		},
+		"face=ceiling,facing=south,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"x": 180
+		},
+		"face=ceiling,facing=north,powered=true": {
+			"model": "artisanat:block/mangrove_wood_button/pressed",
+			"x": 180,
+			"y": 180
+		}
+	}
+}

--- a/src/main/resources/assets/artisanat/blockstates/mangrove_wood_slab.json
+++ b/src/main/resources/assets/artisanat/blockstates/mangrove_wood_slab.json
@@ -1,0 +1,13 @@
+{
+	"variants": {
+		"type=bottom": {
+			"model": "artisanat:block/mangrove_wood_slab/bottom"
+		},
+		"type=top": {
+			"model": "artisanat:block/mangrove_wood_slab/top"
+		},
+		"type=double": {
+			"model": "minecraft:block/mangrove_wood"
+		}
+	}
+}

--- a/src/main/resources/assets/artisanat/blockstates/mangrove_wood_stairs.json
+++ b/src/main/resources/assets/artisanat/blockstates/mangrove_wood_stairs.json
@@ -1,0 +1,209 @@
+{
+	"variants": {
+		"facing=east,half=bottom,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight"
+		},
+		"facing=west,half=bottom,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight",
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=south,half=bottom,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight",
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=north,half=bottom,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight",
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=east,half=bottom,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer"
+		},
+		"facing=west,half=bottom,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=south,half=bottom,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=north,half=bottom,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=east,half=bottom,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=west,half=bottom,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=south,half=bottom,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer"
+		},
+		"facing=north,half=bottom,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=east,half=bottom,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner"
+		},
+		"facing=west,half=bottom,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=south,half=bottom,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=north,half=bottom,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=east,half=bottom,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=west,half=bottom,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=south,half=bottom,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner"
+		},
+		"facing=north,half=bottom,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=east,half=top,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight",
+			"x": 180,
+			"uvlock": true
+		},
+		"facing=west,half=top,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight",
+			"x": 180,
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=south,half=top,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight",
+			"x": 180,
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=north,half=top,shape=straight": {
+			"model": "artisanat:block/mangrove_wood_stairs/straight",
+			"x": 180,
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=east,half=top,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=west,half=top,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=south,half=top,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=north,half=top,shape=outer_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"uvlock": true
+		},
+		"facing=east,half=top,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"uvlock": true
+		},
+		"facing=west,half=top,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=south,half=top,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=north,half=top,shape=outer_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/outer",
+			"x": 180,
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=east,half=top,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=west,half=top,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"y": 270,
+			"uvlock": true
+		},
+		"facing=south,half=top,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=north,half=top,shape=inner_right": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"uvlock": true
+		},
+		"facing=east,half=top,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"uvlock": true
+		},
+		"facing=west,half=top,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"y": 180,
+			"uvlock": true
+		},
+		"facing=south,half=top,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"y": 90,
+			"uvlock": true
+		},
+		"facing=north,half=top,shape=inner_left": {
+			"model": "artisanat:block/mangrove_wood_stairs/inner",
+			"x": 180,
+			"y": 270,
+			"uvlock": true
+		}
+	}
+}

--- a/src/main/resources/assets/artisanat/lang/en_us.json
+++ b/src/main/resources/assets/artisanat/lang/en_us.json
@@ -9,6 +9,7 @@
 	"block.artisanat.jungle_wood_stairs": "Jungle Wood Stairs",
 	"block.artisanat.acacia_wood_stairs": "Acacia Wood Stairs",
 	"block.artisanat.dark_oak_wood_stairs": "Dark Oak Wood Stairs",
+	"block.artisanat.mangrove_wood_stairs": "Mangrove Wood Stairs",
 	"block.artisanat.crimson_hyphae_stairs": "Crimson Hyphae Stairs",
 	"block.artisanat.warped_hyphae_stairs": "Warped Hyphae Stairs",
 
@@ -18,6 +19,7 @@
 	"block.artisanat.jungle_wood_slab": "Jungle Wood Slab",
 	"block.artisanat.acacia_wood_slab": "Acacia Wood Slab",
 	"block.artisanat.dark_oak_wood_slab": "Dark Oak Wood Slab",
+	"block.artisanat.mangrove_wood_slab": "Mangrove Wood Slab",
 	"block.artisanat.crimson_hyphae_slab": "Crimson Hyphae Slab",
 	"block.artisanat.warped_hyphae_slab": "Warped Hyphae Slab",
 
@@ -27,6 +29,7 @@
 	"block.artisanat.jungle_wood_button": "Jungle Wood Button",
 	"block.artisanat.acacia_wood_button": "Acacia Wood Button",
 	"block.artisanat.dark_oak_wood_button": "Dark Oak Wood Button",
+	"block.artisanat.mangrove_wood_button": "Mangrove Wood Button",
 	"block.artisanat.crimson_hyphae_button": "Crimson Hyphae Button",
 	"block.artisanat.warped_hyphae_button": "Warped Hyphae Button",
 

--- a/src/main/resources/assets/artisanat/models/block/mangrove_wood_button/pressed.json
+++ b/src/main/resources/assets/artisanat/models/block/mangrove_wood_button/pressed.json
@@ -1,0 +1,6 @@
+{
+	"parent": "block/button_pressed",
+	"textures": {
+		"texture": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/block/mangrove_wood_button/unpressed.json
+++ b/src/main/resources/assets/artisanat/models/block/mangrove_wood_button/unpressed.json
@@ -1,0 +1,6 @@
+{
+	"parent": "block/button",
+	"textures": {
+		"texture": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/block/mangrove_wood_slab/bottom.json
+++ b/src/main/resources/assets/artisanat/models/block/mangrove_wood_slab/bottom.json
@@ -1,0 +1,8 @@
+{
+	"parent": "block/slab",
+	"textures": {
+		"bottom": "minecraft:block/mangrove_log",
+		"top": "minecraft:block/mangrove_log",
+		"side": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/block/mangrove_wood_slab/top.json
+++ b/src/main/resources/assets/artisanat/models/block/mangrove_wood_slab/top.json
@@ -1,0 +1,8 @@
+{
+	"parent": "block/slab_top",
+	"textures": {
+		"bottom": "minecraft:block/mangrove_log",
+		"top": "minecraft:block/mangrove_log",
+		"side": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/block/mangrove_wood_stairs/inner.json
+++ b/src/main/resources/assets/artisanat/models/block/mangrove_wood_stairs/inner.json
@@ -1,0 +1,8 @@
+{
+	"parent": "block/inner_stairs",
+	"textures": {
+		"bottom": "minecraft:block/mangrove_log",
+		"top": "minecraft:block/mangrove_log",
+		"side": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/block/mangrove_wood_stairs/outer.json
+++ b/src/main/resources/assets/artisanat/models/block/mangrove_wood_stairs/outer.json
@@ -1,0 +1,8 @@
+{
+	"parent": "block/outer_stairs",
+	"textures": {
+		"bottom": "minecraft:block/mangrove_log",
+		"top": "minecraft:block/mangrove_log",
+		"side": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/block/mangrove_wood_stairs/straight.json
+++ b/src/main/resources/assets/artisanat/models/block/mangrove_wood_stairs/straight.json
@@ -1,0 +1,8 @@
+{
+	"parent": "block/stairs",
+	"textures": {
+		"bottom": "minecraft:block/mangrove_log",
+		"top": "minecraft:block/mangrove_log",
+		"side": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/item/mangrove_wood_button.json
+++ b/src/main/resources/assets/artisanat/models/item/mangrove_wood_button.json
@@ -1,0 +1,6 @@
+{
+	"parent": "block/button_inventory",
+	"textures": {
+		"texture": "minecraft:block/mangrove_log"
+	}
+}

--- a/src/main/resources/assets/artisanat/models/item/mangrove_wood_slab.json
+++ b/src/main/resources/assets/artisanat/models/item/mangrove_wood_slab.json
@@ -1,0 +1,3 @@
+{
+	"parent": "artisanat:block/mangrove_wood_slab/bottom"
+}

--- a/src/main/resources/assets/artisanat/models/item/mangrove_wood_stairs.json
+++ b/src/main/resources/assets/artisanat/models/item/mangrove_wood_stairs.json
@@ -1,0 +1,3 @@
+{
+	"parent": "artisanat:block/mangrove_wood_stairs/straight"
+}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/mangrove_wood_button.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/mangrove_wood_button.json
@@ -1,0 +1,32 @@
+{
+	"parent": "minecraft:recipes/root",
+	"rewards": {
+		"recipes": [
+			"artisanat:crafting/mangrove_wood_button"
+		]
+	},
+	"criteria": {
+		"has_wood": {
+			"trigger": "minecraft:inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": ["minecraft:mangrove_wood"]
+					}
+				]
+			}
+		},
+		"has_the_recipe": {
+			"trigger": "minecraft:recipe_unlocked",
+			"conditions": {
+				"recipe": "artisanat:crafting/mangrove_wood_button"
+			}
+		}
+	},
+	"requirements": [
+		[
+			"has_wood",
+			"has_the_recipe"
+		]
+	]
+}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/mangrove_wood_slab.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/mangrove_wood_slab.json
@@ -1,0 +1,32 @@
+{
+	"parent": "minecraft:recipes/root",
+	"rewards": {
+		"recipes": [
+			"artisanat:crafting/mangrove_wood_slab"
+		]
+	},
+	"criteria": {
+		"has_wood": {
+			"trigger": "minecraft:inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": ["minecraft:mangrove_wood"]
+					}
+				]
+			}
+		},
+		"has_the_recipe": {
+			"trigger": "minecraft:recipe_unlocked",
+			"conditions": {
+				"recipe": "artisanat:crafting/mangrove_wood_slab"
+			}
+		}
+	},
+	"requirements": [
+		[
+			"has_wood",
+			"has_the_recipe"
+		]
+	]
+}

--- a/src/main/resources/data/artisanat/advancements/recipes/crafting/mangrove_wood_stairs.json
+++ b/src/main/resources/data/artisanat/advancements/recipes/crafting/mangrove_wood_stairs.json
@@ -1,0 +1,32 @@
+{
+	"parent": "minecraft:recipes/root",
+	"rewards": {
+		"recipes": [
+			"artisanat:crafting/mangrove_wood_stairs"
+		]
+	},
+	"criteria": {
+		"has_wood": {
+			"trigger": "minecraft:inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": ["minecraft:mangrove_wood"]
+					}
+				]
+			}
+		},
+		"has_the_recipe": {
+			"trigger": "minecraft:recipe_unlocked",
+			"conditions": {
+				"recipe": "artisanat:crafting/mangrove_wood_stairs"
+			}
+		}
+	},
+	"requirements": [
+		[
+			"has_wood",
+			"has_the_recipe"
+		]
+	]
+}

--- a/src/main/resources/data/artisanat/loot_tables/blocks/mangrove_wood_button.json
+++ b/src/main/resources/data/artisanat/loot_tables/blocks/mangrove_wood_button.json
@@ -1,0 +1,19 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "artisanat:mangrove_wood_button"
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:survives_explosion"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/artisanat/loot_tables/blocks/mangrove_wood_slab.json
+++ b/src/main/resources/data/artisanat/loot_tables/blocks/mangrove_wood_slab.json
@@ -1,0 +1,32 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"functions": [
+						{
+							"function": "minecraft:set_count",
+							"conditions": [
+								{
+									"condition": "minecraft:block_state_property",
+									"block": "artisanat:mangrove_wood_slab",
+									"properties": {
+										"type": "double"
+									}
+								}
+							],
+							"count": 2
+						},
+						{
+							"function": "minecraft:explosion_decay"
+						}
+					],
+					"name": "artisanat:mangrove_wood_slab"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/artisanat/loot_tables/blocks/mangrove_wood_stairs.json
+++ b/src/main/resources/data/artisanat/loot_tables/blocks/mangrove_wood_stairs.json
@@ -1,0 +1,19 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "artisanat:mangrove_wood_stairs"
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:survives_explosion"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/artisanat/recipes/crafting/mangrove_wood_button.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/mangrove_wood_button.json
@@ -1,0 +1,15 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"group": "artisanat:wood_button",
+	"pattern": [
+		"#"
+	],
+	"key": {
+		"#": {
+			"item": "minecraft:mangrove_wood"
+		}
+	},
+	"result": {
+		"item": "artisanat:mangrove_wood_button"
+	}
+}

--- a/src/main/resources/data/artisanat/recipes/crafting/mangrove_wood_slab.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/mangrove_wood_slab.json
@@ -1,0 +1,16 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"group": "artisanat:wood_slab",
+	"pattern": [
+		"###"
+	],
+	"key": {
+		"#": {
+			"item": "minecraft:mangrove_wood"
+		}
+	},
+	"result": {
+		"item": "artisanat:mangrove_wood_slab",
+		"count": 6
+	}
+}

--- a/src/main/resources/data/artisanat/recipes/crafting/mangrove_wood_stairs.json
+++ b/src/main/resources/data/artisanat/recipes/crafting/mangrove_wood_stairs.json
@@ -1,0 +1,18 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"group": "artisanat:wood_stairs",
+	"pattern": [
+		"#  ",
+		"## ",
+		"###"
+	],
+	"key": {
+		"#": {
+			"item": "minecraft:mangrove_wood"
+		}
+	},
+	"result": {
+		"item": "artisanat:mangrove_wood_stairs",
+		"count": 4
+	}
+}

--- a/src/main/resources/data/minecraft/tags/blocks/wooden_buttons.json
+++ b/src/main/resources/data/minecraft/tags/blocks/wooden_buttons.json
@@ -7,6 +7,7 @@
 		"artisanat:jungle_wood_button",
 		"artisanat:acacia_wood_button",
 		"artisanat:dark_oak_wood_button",
+		"artisanat:mangrove_wood_button",
 		"artisanat:crimson_hyphae_button",
 		"artisanat:warped_hyphae_button"
 	]

--- a/src/main/resources/data/minecraft/tags/blocks/wooden_slabs.json
+++ b/src/main/resources/data/minecraft/tags/blocks/wooden_slabs.json
@@ -7,6 +7,7 @@
 		"artisanat:jungle_wood_slab",
 		"artisanat:acacia_wood_slab",
 		"artisanat:dark_oak_wood_slab",
+		"artisanat:mangrove_wood_slab",
 		"artisanat:crimson_hyphae_slab",
 		"artisanat:warped_hyphae_slab"
 	]

--- a/src/main/resources/data/minecraft/tags/blocks/wooden_stairs.json
+++ b/src/main/resources/data/minecraft/tags/blocks/wooden_stairs.json
@@ -7,6 +7,7 @@
 		"artisanat:jungle_wood_stairs",
 		"artisanat:acacia_wood_stairs",
 		"artisanat:dark_oak_wood_stairs",
+		"artisanat:mangrove_wood_stairs",
 		"artisanat:crimson_hyphae_stairs",
 		"artisanat:warped_hyphae_stairs"
 	]

--- a/src/main/resources/data/minecraft/tags/items/wooden_buttons.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_buttons.json
@@ -7,6 +7,7 @@
 		"artisanat:jungle_wood_button",
 		"artisanat:acacia_wood_button",
 		"artisanat:dark_oak_wood_button",
+		"artisanat:mangrove_wood_button",
 		"artisanat:crimson_hyphae_button",
 		"artisanat:warped_hyphae_button"
 	]

--- a/src/main/resources/data/minecraft/tags/items/wooden_slabs.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_slabs.json
@@ -7,6 +7,7 @@
 		"artisanat:jungle_wood_slab",
 		"artisanat:acacia_wood_slab",
 		"artisanat:dark_oak_wood_slab",
+		"artisanat:mangrove_wood_slab",
 		"artisanat:crimson_hyphae_slab",
 		"artisanat:warped_hyphae_slab"
 	]

--- a/src/main/resources/data/minecraft/tags/items/wooden_stairs.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_stairs.json
@@ -7,6 +7,7 @@
 		"artisanat:jungle_wood_stairs",
 		"artisanat:acacia_wood_stairs",
 		"artisanat:dark_oak_wood_stairs",
+		"artisanat:mangrove_wood_stairs",
 		"artisanat:crimson_hyphae_stairs",
 		"artisanat:warped_hyphae_stairs"
 	]


### PR DESCRIPTION
Adds the missing data to have Mangrove wood blocks and items

**Contributor License Agreement**

By submitting code, assets, or documentation to the repository I am hereby agreeing that:

- I grant Hugman the right to use my contributions under the [LGPL v3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html) license.
- My contributions are of my own work and are free of legal restrictions (such as patents or copyrights).